### PR TITLE
Update to bitcoin 0.28.1

### DIFF
--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -18,7 +18,7 @@ sender = []
 receiver = ["rand"]
 
 [dependencies]
-bitcoin = "0.28.2"
+bitcoin = "0.28.1"
 base64 = "0.13.0"
 rand = { version = "0.8.4", optional = true }
 bip21 = "0.1.1"


### PR DESCRIPTION
BDK v0.23.0 relies on 0.28.1, so we should support it for a version.