### PR TITLE
Complete receive payjoin feature groundwork

### DIFF
--- a/payjoin-client/src/main.rs
+++ b/payjoin-client/src/main.rs
@@ -59,7 +59,7 @@ fn main() {
     let psbt = client.wallet_process_psbt(&psbt, None, None, None).unwrap().psbt;
     let psbt = load_psbt_from_base64(psbt.as_bytes()).unwrap();
     println!("Original psbt: {:#?}", psbt);
-    let pj_params = payjoin::sender::Params::with_fee_contribution(
+    let pj_params = payjoin::sender::Configuration::with_fee_contribution(
         payjoin::bitcoin::Amount::from_sat(10000),
         None,
     );

--- a/payjoin/Cargo.toml
+++ b/payjoin/Cargo.toml
@@ -23,11 +23,11 @@ base64 = "0.13.0"
 rand = { version = "0.8.4", optional = true }
 bip21 = "0.2.0"
 url = "2.2.2"
+log = { version = "0.4.14"}
 
 [dev-dependencies]
 bitcoind = { version = "0.27.1", features = ["0_21_1"] }
 env_logger = "0.9.0"
-log = "0.4.14"
 
 [package.metadata.docs.rs]
 features = ["sender"]

--- a/payjoin/src/receiver/error.rs
+++ b/payjoin/src/receiver/error.rs
@@ -8,6 +8,7 @@ pub(crate) enum InternalRequestError {
     InvalidContentType(String),
     InvalidContentLength(std::num::ParseIntError),
     ContentLengthTooLarge(u64),
+    SenderParams(super::optional_parameters::Error),
 }
 
 impl From<InternalRequestError> for RequestError {

--- a/payjoin/src/receiver/mod.rs
+++ b/payjoin/src/receiver/mod.rs
@@ -153,7 +153,7 @@ impl UnlockedProposal {
         self.psbt.unsigned_tx.input.iter().map(|input| &input.previous_output)
     }
 
-    pub fn assume_locked(self) -> Proposal { Proposal { psbt: self.psbt } }
+    pub fn psbt(self) -> Psbt { self.psbt }
 }
 
 /// Transaction that must be broadcasted.
@@ -161,7 +161,7 @@ impl UnlockedProposal {
 pub struct MustBroadcast(pub bitcoin::Transaction);
 
 pub struct Proposal {
-    psbt: Psbt,
+    pub psbt: Psbt,
 }
 
 /*

--- a/payjoin/src/receiver/mod.rs
+++ b/payjoin/src/receiver/mod.rs
@@ -2,9 +2,11 @@ use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::{AddressType, Script, TxOut};
 
 mod error;
+mod optional_parameters;
 
 use error::InternalRequestError;
 pub use error::RequestError;
+use optional_parameters::Params;
 
 pub trait Headers {
     fn get_header(&self, key: &str) -> Option<&str>;
@@ -12,18 +14,22 @@ pub trait Headers {
 
 pub struct UncheckedProposal {
     psbt: Psbt,
+    params: Params,
 }
 
 pub struct MaybeInputsOwned {
     psbt: Psbt,
+    params: Params,
 }
 
 pub struct MaybeMixedInputScripts {
     psbt: Psbt,
+    params: Params,
 }
 
 pub struct MaybeInputsSeen {
     psbt: Psbt,
+    params: Params,
 }
 
 impl UncheckedProposal {
@@ -55,7 +61,12 @@ impl UncheckedProposal {
         let mut reader = base64::read::DecoderReader::new(&mut limited, base64::STANDARD);
         let psbt = Psbt::consensus_decode(&mut reader).map_err(InternalRequestError::Decode)?;
 
-        Ok(UncheckedProposal { psbt })
+        let pairs = url::form_urlencoded::parse(query.as_bytes());
+        let params = Params::from_query_pairs(pairs).map_err(InternalRequestError::SenderParams)?;
+
+        // TODO check that params are valid for the request's Original PSBT
+
+        Ok(UncheckedProposal { psbt, params })
     }
 
     /// The Sender's Original PSBT
@@ -76,7 +87,7 @@ impl UncheckedProposal {
     ///
     /// Call this after checking downstream.
     pub fn assume_tested_and_scheduled_broadcast(self) -> MaybeInputsOwned {
-        MaybeInputsOwned { psbt: self.psbt }
+        MaybeInputsOwned { psbt: self.psbt, params: self.params }
     }
 
     /// Call this method if the only way to initiate a PayJoin with this receiver
@@ -85,7 +96,7 @@ impl UncheckedProposal {
     /// So-called "non-interactive" receivers, like payment processors, that allow arbitrary requests are otherwise vulnerable to probing attacks.
     /// Those receivers call `get_transaction_to_check_broadcast()` and `attest_tested_and_scheduled_broadcast()` after making those checks downstream.
     pub fn assume_interactive_receive_endpoint(self) -> MaybeInputsOwned {
-        MaybeInputsOwned { psbt: self.psbt }
+        MaybeInputsOwned { psbt: self.psbt, params: self.params }
     }
 }
 
@@ -103,7 +114,7 @@ impl MaybeInputsOwned {
     /// An attacker could try to spend receiver's own inputs. This check prevents that.
     /// Call this after checking downstream.
     pub fn assume_inputs_not_owned(self) -> MaybeMixedInputScripts {
-        MaybeMixedInputScripts { psbt: self.psbt }
+        MaybeMixedInputScripts { psbt: self.psbt, params: self.params }
     }
 }
 
@@ -122,7 +133,7 @@ impl MaybeMixedInputScripts {
     /// Note: mixed spends do not necessarily indicate distinct wallet fingerprints.
     /// This check is intended to prevent some types of wallet fingerprinting.
     pub fn assume_no_mixed_input_scripts(self) -> MaybeInputsSeen {
-        MaybeInputsSeen { psbt: self.psbt }
+        MaybeInputsSeen { psbt: self.psbt, params: self.params }
     }
 }
 
@@ -226,7 +237,11 @@ mod test {
 
         let body = original_psbt.as_bytes();
         let headers = MockHeaders::new(body.len() as u64);
-        UncheckedProposal::from_request(body, "", headers)
+        UncheckedProposal::from_request(
+            body,
+            "?maxadditionalfeecontribution=0.00000182?additionalfeeoutputindex=0",
+            headers,
+        )
     }
 
     #[test]

--- a/payjoin/src/receiver/mod.rs
+++ b/payjoin/src/receiver/mod.rs
@@ -151,12 +151,13 @@ impl MaybeInputsSeen {
     ///
     /// Call this after checking downstream.
     pub fn assume_no_inputs_seen_before(self) -> UnlockedProposal {
-        UnlockedProposal { psbt: self.psbt }
+        UnlockedProposal { psbt: self.psbt, params: self.params }
     }
 }
 
 pub struct UnlockedProposal {
     psbt: Psbt,
+    params: Params,
 }
 
 impl UnlockedProposal {
@@ -165,15 +166,15 @@ impl UnlockedProposal {
     }
 
     pub fn psbt(self) -> Psbt { self.psbt }
+
+    pub fn is_output_substitution_disabled(&self) -> bool {
+        self.params.disable_output_substitution
+    }
 }
 
 /// Transaction that must be broadcasted.
 #[must_use = "The transaction must be broadcasted to prevent abuse"]
 pub struct MustBroadcast(pub bitcoin::Transaction);
-
-pub struct Proposal {
-    pub psbt: Psbt,
-}
 
 /*
 impl Proposal {

--- a/payjoin/src/receiver/optional_parameters.rs
+++ b/payjoin/src/receiver/optional_parameters.rs
@@ -1,0 +1,97 @@
+use std::borrow::Borrow;
+use std::fmt;
+
+use crate::fee_rate::FeeRate;
+
+#[derive(Debug)]
+pub(crate) struct Params {
+    // version
+    // v: usize,
+    // disableoutputsubstitution
+    pub disable_output_substitution: bool,
+    // maxadditionalfeecontribution, additionalfeeoutputindex
+    pub additional_fee_contribution: Option<(bitcoin::Amount, usize)>,
+    // minfeerate
+    pub min_feerate: FeeRate,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Params {
+            disable_output_substitution: false,
+            additional_fee_contribution: None,
+            min_feerate: FeeRate::ZERO,
+        }
+    }
+}
+
+impl Params {
+    #[cfg(feature = "receiver")]
+    pub fn from_query_pairs<K, V, I>(pairs: I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = (K, V)>,
+        K: Borrow<str> + Into<String>,
+        V: Borrow<str> + Into<String>,
+    {
+        let mut params = Params::default();
+
+        let mut additional_fee_output_index = None;
+        let mut max_additional_fee_contribution = None;
+
+        for (k, v) in pairs {
+            match (k.borrow(), v.borrow()) {
+                ("v", v) =>
+                    if v != "1" {
+                        return Err(Error::UnknownVersion);
+                    },
+                ("additionalfeeoutputindex", index) =>
+                    if let Ok(index) = index.parse::<usize>() {
+                        additional_fee_output_index = Some(index);
+                    },
+                ("maxadditionalfeecontribution", fee) => {
+                    max_additional_fee_contribution =
+                        bitcoin::Amount::from_str_in(&fee, bitcoin::Denomination::Bitcoin).ok();
+                }
+                ("minfeerate", feerate) =>
+                    params.min_feerate = match feerate.parse::<u64>() {
+                        Ok(rate) => FeeRate::from_sat_per_vb(rate),
+                        Err(e) => return Err(Error::FeeRate(e)),
+                    },
+                ("disableoutputsubstitution", v) =>
+                    params.disable_output_substitution = v == "true",
+                _ => (),
+            }
+        }
+        if let (Some(amount), Some(index)) =
+            (max_additional_fee_contribution, additional_fee_output_index)
+        {
+            params.additional_fee_contribution = Some((amount, index));
+        }
+
+        Ok(params)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum Error {
+    UnknownVersion,
+    FeeRate(std::num::ParseIntError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::UnknownVersion => write!(f, "unknown version"),
+            Error::FeeRate(_) => write!(f, "could not parse feerate"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::FeeRate(error) => Some(error),
+            _ => None,
+        }
+    }
+}

--- a/payjoin/src/uri.rs
+++ b/payjoin/src/uri.rs
@@ -42,7 +42,7 @@ pub trait PjUriExt: sealed::UriExt {
     fn create_pj_request(
         self,
         psbt: bitcoin::util::psbt::PartiallySignedTransaction,
-        params: sender::Params,
+        params: sender::Configuration,
     ) -> Result<(sender::Request, sender::Context), sender::CreateRequestError>;
 }
 
@@ -55,7 +55,7 @@ impl<'a> PjUriExt for PjUri<'a> {
     fn create_pj_request(
         self,
         psbt: bitcoin::util::psbt::PartiallySignedTransaction,
-        params: sender::Params,
+        params: sender::Configuration,
     ) -> Result<(sender::Request, sender::Context), sender::CreateRequestError> {
         sender::from_psbt_and_uri(
             psbt.try_into()

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -81,9 +81,12 @@ mod integration {
         let headers = HeaderMock::from_vec(&req.body);
 
         // Receiver receive payjoin proposal, IRL it will be an HTTP request (over ssl or onion)
-        let _proposal =
-            payjoin::receiver::UncheckedProposal::from_request(req.body.as_slice(), "", headers)
-                .unwrap();
+        let proposal = payjoin::receiver::UncheckedProposal::from_request(
+            req.body.as_slice(),
+            req.url.query().unwrap_or(""),
+            headers,
+        )
+        .unwrap();
 
         // TODO
     }

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -73,7 +73,7 @@ mod integration {
         let psbt = sender.wallet_process_psbt(&psbt, None, None, None).unwrap().psbt;
         let psbt = load_psbt_from_base64(psbt.as_bytes()).unwrap();
         debug!("Original psbt: {:#?}", psbt);
-        let pj_params = payjoin::sender::Params::with_fee_contribution(
+        let pj_params = payjoin::sender::Configuration::with_fee_contribution(
             payjoin::bitcoin::Amount::from_sat(10000),
             None,
         );


### PR DESCRIPTION
The absolute minimum requirements to use this branch payjoin crate release as a dependency for receiving a PayJoin (in integration tests, nolooking, and hopefully a bitcoind payjoin-server). It's still missing output substitution and coin selection logic, but that can be scripted as in https://github.com/kixunil/loptos for a experiments before it's part of the library.

- [x] Implement psbt() for a checked proposal
- [x] let receiver parse sender optional parameters
- [x] expose is_output_substitution_disabled

This is largely a redeux of the "Parse sender params" change reviewed in both https://github.com/Kixunil/payjoin/pull/30 and https://github.com/Kixunil/payjoin/pull/27 by @Kixunil and @RCasatta 

## Notable Design Decisions

- only allow access to proposal `psbt()` once the safety checks are complete.
- `optional_parameters` is only used in the `receiver` feature so it's put in that folder. I still think ultimately `optional_parameters::Params` should be the type for validation and `sender::Configuration` should depend on it. They are the Sender's optional parameters after all, the receiver just needs to parse them.
- Unlike the prior work where `log` was optional, we depend on it here.
- use `Proposal` trait & `impl_proposal!` macro on intermediate type state to expose common `output_substitution_disabled`  parameter

tagging @cryptoquick also. in case you're in getting a receiver into bitmask or at least distributing software bitmask can send PayJoins to :)
