### PR TITLE
Abstract receive into a library

### DIFF
--- a/payjoin/src/psbt.rs
+++ b/payjoin/src/psbt.rs
@@ -65,6 +65,21 @@ impl Psbt {
                 .map_err(|error| PsbtInputsError { index, error })
         })
     }
+
+    pub fn calculate_fee(&self) -> bitcoin::Amount {
+        let mut total_outputs = bitcoin::Amount::ZERO;
+        let mut total_inputs = bitcoin::Amount::ZERO;
+
+        for output in &self.unsigned_tx.output {
+            total_outputs += bitcoin::Amount::from_sat(output.value);
+        }
+
+        for input in self.input_pairs() {
+            total_inputs += bitcoin::Amount::from_sat(input.previous_txout().unwrap().value);
+        }
+
+        total_inputs - total_outputs
+    }
 }
 
 impl From<Psbt> for UncheckedPsbt {

--- a/payjoin/src/psbt.rs
+++ b/payjoin/src/psbt.rs
@@ -96,6 +96,10 @@ impl std::ops::Deref for Psbt {
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 
+impl std::ops::DerefMut for Psbt {
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+}
+
 pub(crate) struct InputPair<'a> {
     pub txin: &'a TxIn,
     pub psbtin: &'a psbt::Input,

--- a/payjoin/src/receiver/error.rs
+++ b/payjoin/src/receiver/error.rs
@@ -11,6 +11,8 @@ pub(crate) enum InternalRequestError {
     SenderParams(super::optional_parameters::Error),
     /// The raw PSBT fails bip78-specific validation.
     Psbt(crate::psbt::InconsistentPsbt),
+    /// The Original PSBT has no output for the receiver.
+    MissingPayment,
 }
 
 impl From<InternalRequestError> for RequestError {

--- a/payjoin/src/receiver/error.rs
+++ b/payjoin/src/receiver/error.rs
@@ -13,6 +13,8 @@ pub(crate) enum InternalRequestError {
     Psbt(crate::psbt::InconsistentPsbt),
     /// The Original PSBT has no output for the receiver.
     MissingPayment,
+    /// minimum is amount but additionalfeecontribution is (amount, index)
+    InsufficientFee(bitcoin::Amount, Option<(bitcoin::Amount, usize)>),
 }
 
 impl From<InternalRequestError> for RequestError {

--- a/payjoin/src/receiver/mod.rs
+++ b/payjoin/src/receiver/mod.rs
@@ -218,6 +218,12 @@ impl PayjoinProposal {
             ..Default::default()
         });
     }
+
+    /// Just replace an output address with
+    pub fn substitute_output_address(&mut self, substitute_address: bitcoin::Address) {
+        self.psbt.unsigned_tx.output[self.owned_vout].script_pubkey =
+            substitute_address.script_pubkey();
+    }
 }
 
 /// Transaction that must be broadcasted.

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -167,22 +167,11 @@ mod integration {
         let outpoint_to_contribute =
             bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
         payjoin.contribute_new_input(txo_to_contribute, outpoint_to_contribute);
-        // *
-        //      TODO add sender additionalfee to our output
-        let mut payjoin_proposal_psbt = payjoin.psbt().clone();
 
-        let receiver_vout = 0; // correct???
-                               //      TODO add selected receiver input utxo
-                               //      substitute receiver output
         let receiver_substitute_address = receiver.get_new_address(None, None).unwrap();
-        let substitute_txout = bitcoin::TxOut {
-            value: payjoin_proposal_psbt.unsigned_tx.output[receiver_vout].value,
-            script_pubkey: receiver_substitute_address.script_pubkey(),
-        };
-        payjoin_proposal_psbt.unsigned_tx.output[receiver_vout] = substitute_txout;
-        payjoin_proposal_psbt
-            .outputs
-            .resize_with(payjoin_proposal_psbt.unsigned_tx.output.len(), Default::default);
+        payjoin.substitute_output_address(receiver_substitute_address);
+
+        let payjoin_proposal_psbt = payjoin.psbt();
 
         //      TODO identify sender fee output if one exists and set the appropriate feerate
         //      let minRelayFeeRate =

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -151,7 +151,11 @@ mod integration {
         let mut payjoin = proposal
             .assume_inputs_not_owned()
             .assume_no_mixed_input_scripts()
-            .assume_no_inputs_seen_before();
+            .assume_no_inputs_seen_before()
+            .identify_receiver_outputs(|output_script| {
+                let address = bitcoin::Address::from_script(&output_script, bitcoin::Network::Regtest).unwrap();
+                receiver.get_address_info(&address).unwrap().is_mine.unwrap()
+            }).expect("Receiver should have at least one output");
 
         // Select receiver payjoin inputs. TODO Lock them.
         let available_inputs = receiver.list_unspent(None, None, None, None, None).unwrap();

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -166,7 +166,7 @@ mod integration {
         };
         let outpoint_to_contribute =
             bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
-        payjoin.contribute_new_input(txo_to_contribute, outpoint_to_contribute);
+        payjoin.contribute_witness_input(txo_to_contribute, outpoint_to_contribute);
 
         let receiver_substitute_address = receiver.get_new_address(None, None).unwrap();
         payjoin.substitute_output_address(receiver_substitute_address);

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -4,7 +4,6 @@ mod integration {
     use std::str::FromStr;
 
     use bitcoin::hashes::hex::ToHex;
-    use bitcoin::psbt::Input;
     use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
     use bitcoin::{consensus, Amount};
     use bitcoind::bitcoincore_rpc;
@@ -149,18 +148,10 @@ mod integration {
         let proposal = proposal.assume_tested_and_scheduled_broadcast();
 
         // ⚠️ TODO Receive checklist Original PSBT Checks ⚠️ shipping this is SAFETY CRITICAL to get out of alpha into beta
-        let unlocked = proposal
+        let mut payjoin = proposal
             .assume_inputs_not_owned()
             .assume_no_mixed_input_scripts()
             .assume_no_inputs_seen_before();
-
-        let mut original_psbt = unlocked.psbt();
-        // empty original_psbt signatures because we won't broadcast the original_psbt
-        original_psbt
-            .unsigned_tx
-            .input
-            .iter_mut()
-            .for_each(|txin| txin.script_sig = bitcoin::Script::default());
 
         // Select receiver payjoin inputs. TODO Lock them.
         let available_inputs = receiver.list_unspent(None, None, None, None, None).unwrap();
@@ -168,39 +159,24 @@ mod integration {
         // ⚠️ TODO Select to avoid Unecessary Input and other heuristics. ⚠️ shipping this is SAFETY CRITICAL to get out of alpha into beta
         // This Gist <https://gist.github.com/AdamISZ/4551b947789d3216bacfcb7af25e029e> explains how
 
-        // Update payjoin_psbt
-        // Remove vestigial invalid signature data from the Original PSBT
-        let original_sequence = original_psbt.unsigned_tx.input[0].sequence;
-        let original_psbt =
-            Psbt::from_unsigned_tx(original_psbt.unsigned_tx.clone()).expect("resetting tx failed");
-        let mut payjoin_proposal_psbt = original_psbt.clone();
-
         //  calculate receiver payjoin outputs given receiver payjoin inputs and original_psbt,
-        payjoin_proposal_psbt.inputs.push(Input {
-            witness_utxo: Some(bitcoin::TxOut {
-                value: selected_utxo.amount.to_sat(),
-                script_pubkey: selected_utxo.script_pub_key.clone(),
-            }),
-            ..Default::default()
-        });
-        payjoin_proposal_psbt.unsigned_tx.input.push(bitcoin::TxIn {
-            previous_output: bitcoin::OutPoint {
-                txid: selected_utxo.txid,
-                vout: selected_utxo.vout,
-            },
-            sequence: original_sequence,
-            ..Default::default()
-        });
+        let txo_to_contribute = bitcoin::TxOut {
+            value: selected_utxo.amount.to_sat(),
+            script_pubkey: selected_utxo.script_pub_key.clone(),
+        };
+        let outpoint_to_contribute =
+            bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
+        payjoin.contribute_new_input(txo_to_contribute, outpoint_to_contribute);
         // *
         //      TODO add sender additionalfee to our output
+        let mut payjoin_proposal_psbt = payjoin.psbt().clone();
 
         let receiver_vout = 0; // correct???
                                //      TODO add selected receiver input utxo
                                //      substitute receiver output
         let receiver_substitute_address = receiver.get_new_address(None, None).unwrap();
         let substitute_txout = bitcoin::TxOut {
-            value: payjoin_proposal_psbt.unsigned_tx.output[receiver_vout].value
-                + selected_utxo.amount.to_sat(),
+            value: payjoin_proposal_psbt.unsigned_tx.output[receiver_vout].value,
             script_pubkey: receiver_substitute_address.script_pubkey(),
         };
         payjoin_proposal_psbt.unsigned_tx.output[receiver_vout] = substitute_txout;

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -175,12 +175,7 @@ mod integration {
         let receiver_substitute_address = receiver.get_new_address(None, None).unwrap();
         payjoin.substitute_output_address(receiver_substitute_address);
 
-        let payjoin_proposal_psbt = payjoin.psbt();
-
-        //      TODO identify sender fee output if one exists and set the appropriate feerate
-        //      let minRelayFeeRate =
-        //      TODO if additionalfee > Amount::ZERO { receiver, take it }
-        //          add new_change, new_change.amount = original_psbt change's + receiver_inputs.amount() - sender additionalfees
+        let payjoin_proposal_psbt = payjoin.extract_psbt(None).expect("failed to apply fees");
 
         // Sign payjoin psbt
         let payjoin_base64_string = base64::encode(consensus::serialize(&payjoin_proposal_psbt));


### PR DESCRIPTION
- Abstract receiver contribution
- Abstract output substitution
- Add helper method to find which outputs belong to the receiver
- Calculate and apply appropriate receiver fees on payjoin proposal

This replaces the `impl Proposal` kixunil wrote. The `ReceiverOptions`, `BumpFeePolicy`, and `NewOutputOptions` should still be considered.

## Remaining Options

This version makes `BumpFeePolicy` implicit by instead requesting a receiver-specified min_feerate. If that's `None` or insufficient and the sender's optional parameter min_feerate is not met, the recipient request fails.

Receiver fee outputs are currently selected at random from the receiver outputs. Since they are revenue for the recipient, I think it would make more sense to specify those which output canNOT be fee subtracted for a fee, and only mark those outputs who are e.g. being forwarded by the receiver. Since the receiver would not create change by default, having such a change / fee output would be the specified option.

Payjoin is supposed to be a 2-output tx, so if there's a receiver min_feerate & receiver output they ought to contribute. That may run into an issue in lightning payjoin.

ReceiverOptions's dust_limit is valid.

## Locking inputs

Consider a mechanism to guarantee receiver input utxos are locked before extracting the payjoin psbt. If it were to get spent in two places at once that may be an issue.