### PR TITLE
Validate crate::psbt::Psbt on receiver

### DIFF
--- a/payjoin/src/receiver/error.rs
+++ b/payjoin/src/receiver/error.rs
@@ -9,6 +9,8 @@ pub(crate) enum InternalRequestError {
     InvalidContentLength(std::num::ParseIntError),
     ContentLengthTooLarge(u64),
     SenderParams(super::optional_parameters::Error),
+    /// The raw PSBT fails bip78-specific validation.
+    Psbt(crate::psbt::InconsistentPsbt),
 }
 
 impl From<InternalRequestError> for RequestError {


### PR DESCRIPTION
BIP 78 has a few psbt consistency rules beyond a valid PSBT. This checks those and makes utilities available. PSBTv2 may obsolete it.