### PR TITLE
Payjoin in a privacy preserving way

### DIFF
--- a/payjoin/src/receiver/error.rs
+++ b/payjoin/src/receiver/error.rs
@@ -30,3 +30,20 @@ pub(crate) enum InternalRequestError {
 impl From<InternalRequestError> for RequestError {
     fn from(value: InternalRequestError) -> Self { RequestError(value) }
 }
+
+#[derive(Debug)]
+pub struct SelectionError(InternalSelectionError);
+
+#[derive(Debug)]
+pub(crate) enum InternalSelectionError {
+    /// No candidates available for selection
+    Empty,
+    /// Current privacy selection implementation only supports 2-output transactions
+    TooManyOutputs,
+    /// No selection candidates improve privacy
+    NotFound,
+}
+
+impl From<InternalSelectionError> for SelectionError {
+    fn from(value: InternalSelectionError) -> Self { SelectionError(value) }
+}

--- a/payjoin/src/receiver/mod.rs
+++ b/payjoin/src/receiver/mod.rs
@@ -1,14 +1,15 @@
-use std::cmp::max;
+use std::cmp::{max, min};
+use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use bitcoin::util::psbt::PartiallySignedTransaction as UncheckedPsbt;
-use bitcoin::{AddressType, OutPoint, Script, TxOut};
+use bitcoin::{Amount, OutPoint, Script, TxOut};
 
 mod error;
 mod optional_parameters;
 
-use error::InternalRequestError;
-pub use error::RequestError;
+use error::{InternalRequestError, InternalSelectionError};
+pub use error::{RequestError, SelectionError};
 use optional_parameters::Params;
 use rand::seq::SliceRandom;
 
@@ -251,6 +252,70 @@ impl PayjoinProposal {
 
     pub fn is_output_substitution_disabled(&self) -> bool {
         self.params.disable_output_substitution
+    }
+
+    /// Select receiver input such that the payjoin avoids surveillance.
+    /// Return the input chosen that has been applied to the Proposal.
+    ///
+    /// Proper coin selection allows payjoin to resemble ordinary transactions.
+    /// To ensure the resemblence, a number of heuristics must be avoided.
+    ///
+    /// UIH "Unecessary input heuristic" is one class of them to avoid. We define
+    /// UIH1 and UIH2 according to the BlockSci practice
+    /// BlockSci UIH1 and UIH2:
+    // if min(out) < min(in) then UIH1 else UIH2
+    // https://eprint.iacr.org/2022/589.pdf
+    pub fn try_preserving_privacy(
+        &self,
+        candidate_inputs: HashMap<Amount, OutPoint>,
+    ) -> Result<OutPoint, SelectionError> {
+        if candidate_inputs.is_empty() {
+            return Err(SelectionError::from(InternalSelectionError::Empty));
+        }
+
+        if self.psbt.outputs.len() != 2 {
+            // Current UIH techniques only support many-input, two-output transactions.
+            return Err(SelectionError::from(InternalSelectionError::TooManyOutputs));
+        }
+
+        let min_original_out_sats = self
+            .psbt
+            .unsigned_tx
+            .output
+            .iter()
+            .map(|output| output.value)
+            .min()
+            .unwrap_or(Amount::MAX_MONEY.to_sat());
+
+        let min_original_in_sats = self
+            .psbt
+            .input_pairs()
+            .filter_map(|input| input.previous_txout().ok().map(|txo| txo.value))
+            .min()
+            .unwrap_or(Amount::MAX_MONEY.to_sat());
+
+        // Assume many-input, two output to select the vout for now
+        let prior_payment_sats = self.psbt.unsigned_tx.output[self.owned_vouts[0]].value;
+        for candidate in candidate_inputs {
+            // TODO bound loop by timeout / iterations
+
+            let candidate_sats = candidate.0.to_sat();
+            let candidate_min_out = min(min_original_out_sats, prior_payment_sats + candidate_sats);
+            let candidate_min_in = min(min_original_in_sats, candidate_sats);
+
+            if candidate_min_out < candidate_min_in {
+                // The candidate avoids UIH2 but conforms to UIH1: Optimal change heuristic.
+                // It implies the smallest output is the sender's change address.
+                return Ok(candidate.1);
+            } else {
+                // The candidate conforms to UIH2: Unnecessary input
+                // and could be identified as a potential payjoin
+                continue;
+            }
+        }
+
+        // No suitable privacy preserving selection found
+        Err(SelectionError::from(InternalSelectionError::NotFound))
     }
 
     pub fn contribute_witness_input(&mut self, txo: TxOut, outpoint: OutPoint) {


### PR DESCRIPTION
Select receiver coins such that the payjoin is covert and hides in the crowd. We don't want the resulting transaction to be identifiable as a payjoin. This technique creates a UIH1 tx (optimal change heuristic) so it can not be singled out as payjoin. Based on [btcpay's lead on this problem](https://github.com/btcpayserver/btcpayserver/discussions/4599) and [the gist discussion](https://gist.github.com/AdamISZ/4551b947789d3216bacfcb7af25e029e#gistcomment-4460899)

This change has open problems:

> 1.  I think the sender change can always be identified. ⚠️ While the chosen selection is fast to compute, I don't think this method tries to avoid UIH1 or otherwise creates a false positive UIH1 payjoin. If we create false positive UIH1, this point is moot.

- [x] Ok, so we always create UIH 1 here, but that's good enough to be stenographic for a a first release. The rabbit hole of amount decomposition / transaction structure runs deep. This problem is not solved yet. However, v2 could create false positive UIH1 as BtcPayServer used to.

> 2. The selection time is unbounded. For large utxo lists this may take more than the 30s HTTP request timeout. Therefore, this method should have some sort of timeout mechanism.

- [x] ~~implement a timeout as in btcpay~~ not for alpha

> 3. Errors are not handled. unwrap() everywhere.

- [x] handle errors

> 4. Selected coins aren't locked. Decide whether to accept a function pointer to lock coins or make that responsibility explicit in the doc string.

- [x] This seems unecessary for an alpha

5. It's not tested. Testing around transactions with known heuristic properties will solve 1.

- [x] ~~unit test.~~ not necessary for an alpha but very available in btcpay etc.

> 6. This only supports many-input, 2-output transactions. Many-output transactions SHOULD be supported to support batching as in nolooking.

- [x] Yes, but for another day. nolooking works fine as-is as an alpha without coin selection.

depends on #23 