### PR TITLE
Do receiver's original PSBT checklist

### DIFF
--- a/payjoin/src/receiver/error.rs
+++ b/payjoin/src/receiver/error.rs
@@ -23,6 +23,8 @@ pub(crate) enum InternalRequestError {
     MixedInputScripts(crate::input_type::InputType, crate::input_type::InputType),
     /// Unrecognized input type
     InputType(crate::input_type::InputTypeError),
+    /// Original psbt input has been seen before. This is a bigger problem for "interactive" receivers
+    InputSeen(bitcoin::OutPoint),
 }
 
 impl From<InternalRequestError> for RequestError {

--- a/payjoin/src/receiver/error.rs
+++ b/payjoin/src/receiver/error.rs
@@ -15,6 +15,8 @@ pub(crate) enum InternalRequestError {
     MissingPayment,
     /// minimum is amount but additionalfeecontribution is (amount, index)
     InsufficientFee(bitcoin::Amount, Option<(bitcoin::Amount, usize)>),
+    /// The original PSBT transaction fails the broadcast check
+    OriginalPsbtNotBroadcastable,
 }
 
 impl From<InternalRequestError> for RequestError {

--- a/payjoin/src/receiver/error.rs
+++ b/payjoin/src/receiver/error.rs
@@ -17,6 +17,8 @@ pub(crate) enum InternalRequestError {
     InsufficientFee(bitcoin::Amount, Option<(bitcoin::Amount, usize)>),
     /// The original PSBT transaction fails the broadcast check
     OriginalPsbtNotBroadcastable,
+    /// The sender is trying to spend the receiver input
+    InputOwned(bitcoin::Script),
 }
 
 impl From<InternalRequestError> for RequestError {

--- a/payjoin/src/receiver/error.rs
+++ b/payjoin/src/receiver/error.rs
@@ -19,6 +19,10 @@ pub(crate) enum InternalRequestError {
     OriginalPsbtNotBroadcastable,
     /// The sender is trying to spend the receiver input
     InputOwned(bitcoin::Script),
+    /// The original psbt has mixed input address types that could harm privacy
+    MixedInputScripts(crate::input_type::InputType, crate::input_type::InputType),
+    /// Unrecognized input type
+    InputType(crate::input_type::InputTypeError),
 }
 
 impl From<InternalRequestError> for RequestError {

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -159,9 +159,11 @@ mod integration {
             })
             .expect("Receiver should not own any of the inputs");
 
+        // Receive Check 3: receiver can't sign for proposal inputs
+        let proposal = proposal.check_no_mixed_input_scripts().unwrap();
+
         // ⚠️ TODO Receive checklist Original PSBT Checks ⚠️ shipping this is SAFETY CRITICAL to get out of alpha into beta
         let mut payjoin = proposal
-            .assume_no_mixed_input_scripts()
             .assume_no_inputs_seen_before()
             .identify_receiver_outputs(|output_script| {
                 let address =

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -150,9 +150,17 @@ mod integration {
             })
             .expect("Payjoin proposal should be broadcastable");
 
+        // Receive Check 2: receiver can't sign for proposal inputs
+        let proposal = proposal
+            .check_inputs_not_owned(|input| {
+                let address =
+                    bitcoin::Address::from_script(&input, bitcoin::Network::Regtest).unwrap();
+                receiver.get_address_info(&address).unwrap().is_mine.unwrap()
+            })
+            .expect("Receiver should not own any of the inputs");
+
         // ⚠️ TODO Receive checklist Original PSBT Checks ⚠️ shipping this is SAFETY CRITICAL to get out of alpha into beta
         let mut payjoin = proposal
-            .assume_inputs_not_owned()
             .assume_no_mixed_input_scripts()
             .assume_no_inputs_seen_before()
             .identify_receiver_outputs(|output_script| {

--- a/payjoin/tests/integration.rs
+++ b/payjoin/tests/integration.rs
@@ -162,9 +162,10 @@ mod integration {
         // Receive Check 3: receiver can't sign for proposal inputs
         let proposal = proposal.check_no_mixed_input_scripts().unwrap();
 
-        // ⚠️ TODO Receive checklist Original PSBT Checks ⚠️ shipping this is SAFETY CRITICAL to get out of alpha into beta
+        // Receive Check 4: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
         let mut payjoin = proposal
-            .assume_no_inputs_seen_before()
+            .check_no_inputs_seen_before(|_| false)
+            .unwrap()
             .identify_receiver_outputs(|output_script| {
                 let address =
                     bitcoin::Address::from_script(&output_script, bitcoin::Network::Regtest)


### PR DESCRIPTION
Receiver checks that the original PSBT is not an attack. ~I think some of the iterator code could be refined checks have been refined, but overall the design is correct.~ update: checks refined.

> ## Receiver's original PSBT checklist
> 
> The receiver needs to do some check on the original PSBT before proceeding:
> 
> * Non-interactive receivers (like a payment processor) need to check that the original PSBT is broadcastable. <code>*</code>
> * If the sender included inputs in the original PSBT owned by the receiver, the receiver must either return error <code>original-psbt-rejected</code> or make sure they do not sign those inputs in the payjoin proposal.
> * If the sender's inputs are all from the same scriptPubKey type, the receiver must match the same type. If the receiver can't match the type, they must return error <code>unavailable</code>.
> * Make sure that the inputs included in the original transaction have never been seen before.
> ** This prevent [[#probing-attack|probing attacks]].
> ** This prevent reentrant payjoin, where a sender attempts to use payjoin transaction as a new original transaction for a  new payjoin.
> 
> <code>*</code>: Interactive receivers are not required to validate the original PSBT because they are not exposed to [[#probing-attack|probing attacks]].

[source](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#receivers-original-psbt-checklist)

past attempt: https://github.com/Kixunil/payjoin/pull/33