### PR TITLE
Make check_no_inputs_seen_before rusty

### DIFF
--- a/payjoin/src/receiver/error.rs
+++ b/payjoin/src/receiver/error.rs
@@ -11,6 +11,8 @@ pub(crate) enum InternalRequestError {
     SenderParams(super::optional_parameters::Error),
     /// The raw PSBT fails bip78-specific validation.
     Psbt(crate::psbt::InconsistentPsbt),
+    /// The prevtxout is missing
+    PrevTxOut(crate::psbt::PrevTxOutError),
     /// The Original PSBT has no output for the receiver.
     MissingPayment,
     /// minimum is amount but additionalfeecontribution is (amount, index)

--- a/payjoin/src/receiver/mod.rs
+++ b/payjoin/src/receiver/mod.rs
@@ -191,11 +191,10 @@ impl MaybeInputsSeen {
         self,
         is_known: impl Fn(&OutPoint) -> bool,
     ) -> Result<OutputsUnknown, RequestError> {
-        let psbt: Psbt = Psbt::try_from(self.psbt.clone()).unwrap();
-        let mut input_scripts = psbt.input_pairs().map(|input| input.txin.previous_output);
+        let mut input_scripts: Vec<_> = self.psbt.input_pairs().map(|input| input.txin.previous_output).collect();
 
-        if let Some(known_input) = input_scripts.find(|op| is_known(op)) {
-            return Err(RequestError::from(InternalRequestError::InputSeen(known_input.clone())));
+        if let Some(known_input) = input_scripts.iter_mut().find(|op| is_known(op)) {
+            return Err(RequestError::from(InternalRequestError::InputSeen(known_input.to_owned())));
         }
         Ok(OutputsUnknown { psbt: self.psbt, params: self.params })
     }


### PR DESCRIPTION
I left a little messiness in `check_no_inputs_seen_before` in the form of excess clones that this cleans up. 

just the last commit, really

fix #29 