### PR TITLE
Add sub_only option without receiver input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",


### PR DESCRIPTION
Close #45 

> Run a receiver that only substitutes the payment output for a fresh address. Because this version will not ever contribute inputs, It serves as a light-weight way to receive on-chain payments in a private fashion.
> Compared to payment codes
> Pros
> 
>    - No notification transaction
>  -   No worry about revocation, either the endpoint is online or not
> 
> Cons
> 
>  -   Requires interaction (Though fetching a paynym relation to a payment code does, too)
>    - Must host https endpoint. Output substitution requires e2ee to be secure, so this won't work with a relay until serverless payjoin comes around.
> 