### PR TITLE
Handle `payjoin-client` errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1150,7 @@ dependencies = [
 name = "payjoin-client"
 version = "0.1.15"
 dependencies = [
+ "anyhow",
  "base64",
  "bitcoin",
  "bitcoincore-rpc",

--- a/payjoin-client/Cargo.toml
+++ b/payjoin-client/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 native-tls-vendored = ["reqwest/native-tls-vendored"]
 
 [dependencies]
+anyhow = "1.0.70"
 bitcoin = "0.29.2"
 payjoin = { path = "../payjoin", features = ["sender", "receiver"] }
 bitcoincore-rpc = "0.16.0"

--- a/payjoin-client/src/main.rs
+++ b/payjoin-client/src/main.rs
@@ -8,6 +8,7 @@ use bitcoincore_rpc::RpcApi;
 use clap::{arg, Arg, Command};
 use payjoin::bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use payjoin::{PjUriExt, UriExt};
+use rouille::{Request, Response};
 
 fn main() -> Result<()> {
     env_logger::init();
@@ -40,7 +41,7 @@ fn main() -> Result<()> {
                 sub_matches.get_one::<String>("AMOUNT").context("Missing AMOUNT argument")?;
             let endpoint =
                 sub_matches.get_one::<String>("ENDPOINT").context("Missing ENDPOINT argument")?;
-            receive_payjoin(bitcoind, amount, endpoint);
+            receive_payjoin(bitcoind, amount, endpoint)?;
         }
         _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
     }
@@ -118,7 +119,9 @@ fn send_payjoin(
         .with_context(|| "Failed to finalize PSBT")?
         .hex
         .ok_or_else(|| anyhow!("Incomplete PSBT"))?;
-    bitcoind.send_raw_transaction(&tx).with_context(|| "Failed to send raw transaction")?;
+    let txid =
+        bitcoind.send_raw_transaction(&tx).with_context(|| "Failed to send raw transaction")?;
+    log::info!("Transaction sent: {}", txid);
     Ok(())
 }
 
@@ -127,10 +130,7 @@ fn receive_payjoin(
     amount_arg: &str,
     endpoint_arg: &str,
 ) -> Result<()> {
-    use bitcoin::hashes::hex::ToHex;
-    use bitcoin::OutPoint;
     use payjoin::Uri;
-    use rouille::Response;
 
     let pj_receiver_address = bitcoind.get_new_address(None, None)?;
     let amount = Amount::from_sat(amount_arg.parse()?);
@@ -149,109 +149,111 @@ fn receive_payjoin(
     println!("Awaiting payjoin at BIP 21 Payjoin Uri:");
     println!("{}", pj_uri_string);
 
-    rouille::start_server("0.0.0.0:3000", move |req| {
-        let headers = Headers(req.headers());
-        let proposal = payjoin::receiver::UncheckedProposal::from_request(
-            req.data().unwrap(),
-            req.raw_query_string(),
-            headers,
-        )
+    rouille::start_server("0.0.0.0:3000", move |req| handle_payjoin_request(&req, &bitcoind));
+}
+
+fn handle_payjoin_request(req: &Request, bitcoind: &bitcoincore_rpc::Client) -> Response {
+    use bitcoin::hashes::hex::ToHex;
+    use bitcoin::OutPoint;
+
+    let headers = Headers(req.headers());
+    let proposal = payjoin::receiver::UncheckedProposal::from_request(
+        req.data().unwrap(),
+        req.raw_query_string(),
+        headers,
+    )
+    .unwrap();
+
+    // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
+    let _to_broadcast_in_failure_case = proposal.get_transaction_to_schedule_broadcast();
+
+    // The network is used for checks later
+    let network = match bitcoind.get_blockchain_info().unwrap().chain.as_str() {
+        "main" => bitcoin::Network::Bitcoin,
+        "test" => bitcoin::Network::Testnet,
+        "regtest" => bitcoin::Network::Regtest,
+        _ => panic!("Unknown network"),
+    };
+
+    // Receive Check 1: Can Broadcast
+    let proposal = proposal
+        .check_can_broadcast(|tx| {
+            bitcoind
+                .test_mempool_accept(&[bitcoin::consensus::encode::serialize(&tx).to_hex()])
+                .unwrap()
+                .first()
+                .unwrap()
+                .allowed
+        })
+        .expect("Payjoin proposal should be broadcastable");
+    log::trace!("check1");
+
+    // Receive Check 2: receiver can't sign for proposal inputs
+    let proposal = proposal
+        .check_inputs_not_owned(|input| {
+            let address = bitcoin::Address::from_script(&input, network).unwrap();
+            bitcoind.get_address_info(&address).unwrap().is_mine.unwrap()
+        })
+        .expect("Receiver should not own any of the inputs");
+    log::trace!("check2");
+    // Receive Check 3: receiver can't sign for proposal inputs
+    let proposal = proposal.check_no_mixed_input_scripts().unwrap();
+    log::trace!("check3");
+
+    // Receive Check 4: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
+    let mut payjoin = proposal
+        .check_no_inputs_seen_before(|_| false)
+        .unwrap()
+        .identify_receiver_outputs(|output_script| {
+            let address = bitcoin::Address::from_script(&output_script, network).unwrap();
+            bitcoind.get_address_info(&address).unwrap().is_mine.unwrap()
+        })
+        .expect("Receiver should have at least one output");
+    log::trace!("check4");
+
+    // Select receiver payjoin inputs.
+    let available_inputs = bitcoind.list_unspent(None, None, None, None, None).unwrap();
+    let candidate_inputs: HashMap<Amount, OutPoint> = available_inputs
+        .iter()
+        .map(|i| (i.amount, OutPoint { txid: i.txid, vout: i.vout }))
+        .collect();
+
+    let selected_outpoint = payjoin.try_preserving_privacy(candidate_inputs).expect("gg");
+    let selected_utxo = available_inputs
+        .iter()
+        .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)
         .unwrap();
+    log::debug!("selected utxo: {:#?}", selected_utxo);
 
-        // in a payment processor where the sender could go offline, this is where you schedule to broadcast the original_tx
-        let _to_broadcast_in_failure_case = proposal.get_transaction_to_schedule_broadcast();
+    //  calculate receiver payjoin outputs given receiver payjoin inputs and original_psbt,
+    let txo_to_contribute = bitcoin::TxOut {
+        value: selected_utxo.amount.to_sat(),
+        script_pubkey: selected_utxo.script_pub_key.clone(),
+    };
+    let outpoint_to_contribute =
+        bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
+    payjoin.contribute_witness_input(txo_to_contribute, outpoint_to_contribute);
 
-        // The network is used for checks later
-        let network = match bitcoind.get_blockchain_info().unwrap().chain.as_str() {
-            "main" => bitcoin::Network::Bitcoin,
-            "test" => bitcoin::Network::Testnet,
-            "regtest" => bitcoin::Network::Regtest,
-            _ => panic!("Unknown network"),
-        };
+    let receiver_substitute_address = bitcoind.get_new_address(None, None).unwrap();
+    payjoin.substitute_output_address(receiver_substitute_address);
 
-        // Receive Check 1: Can Broadcast
-        let proposal = proposal
-            .check_can_broadcast(|tx| {
-                bitcoind
-                    .test_mempool_accept(&[bitcoin::consensus::encode::serialize(&tx).to_hex()])
-                    .unwrap()
-                    .first()
-                    .unwrap()
-                    .allowed
-            })
-            .expect("Payjoin proposal should be broadcastable");
-        log::trace!("check1");
+    let payjoin_proposal_psbt = payjoin.apply_fee(Some(1)).expect("failed to apply fees");
 
-        // Receive Check 2: receiver can't sign for proposal inputs
-        let proposal = proposal
-            .check_inputs_not_owned(|input| {
-                let address = bitcoin::Address::from_script(&input, network).unwrap();
-                bitcoind.get_address_info(&address).unwrap().is_mine.unwrap()
-            })
-            .expect("Receiver should not own any of the inputs");
-        log::trace!("check2");
-        // Receive Check 3: receiver can't sign for proposal inputs
-        let proposal = proposal.check_no_mixed_input_scripts().unwrap();
-        log::trace!("check3");
+    log::debug!("Extracted PSBT: {:#?}", payjoin_proposal_psbt);
+    // Sign payjoin psbt
+    let payjoin_base64_string =
+        base64::encode(bitcoin::consensus::serialize(&payjoin_proposal_psbt));
+    // `wallet_process_psbt` adds available utxo data and finalizes
+    let payjoin_proposal_psbt =
+        bitcoind.wallet_process_psbt(&payjoin_base64_string, None, None, Some(false)).unwrap().psbt;
+    let payjoin_proposal_psbt = load_psbt_from_base64(payjoin_proposal_psbt.as_bytes()).unwrap();
+    let payjoin_proposal_psbt =
+        payjoin.prepare_psbt(payjoin_proposal_psbt).expect("failed to prepare psbt");
+    log::debug!("Receiver's PayJoin proposal PSBT Rsponse: {:#?}", payjoin_proposal_psbt);
 
-        // Receive Check 4: have we seen this input before? More of a check for non-interactive i.e. payment processor receivers.
-        let mut payjoin = proposal
-            .check_no_inputs_seen_before(|_| false)
-            .unwrap()
-            .identify_receiver_outputs(|output_script| {
-                let address = bitcoin::Address::from_script(&output_script, network).unwrap();
-                bitcoind.get_address_info(&address).unwrap().is_mine.unwrap()
-            })
-            .expect("Receiver should have at least one output");
-        log::trace!("check4");
-
-        // Select receiver payjoin inputs.
-        let available_inputs = bitcoind.list_unspent(None, None, None, None, None).unwrap();
-        let candidate_inputs: HashMap<Amount, OutPoint> = available_inputs
-            .iter()
-            .map(|i| (i.amount, OutPoint { txid: i.txid, vout: i.vout }))
-            .collect();
-
-        let selected_outpoint = payjoin.try_preserving_privacy(candidate_inputs).expect("gg");
-        let selected_utxo = available_inputs
-            .iter()
-            .find(|i| i.txid == selected_outpoint.txid && i.vout == selected_outpoint.vout)
-            .unwrap();
-        log::debug!("selected utxo: {:#?}", selected_utxo);
-
-        //  calculate receiver payjoin outputs given receiver payjoin inputs and original_psbt,
-        let txo_to_contribute = bitcoin::TxOut {
-            value: selected_utxo.amount.to_sat(),
-            script_pubkey: selected_utxo.script_pub_key.clone(),
-        };
-        let outpoint_to_contribute =
-            bitcoin::OutPoint { txid: selected_utxo.txid, vout: selected_utxo.vout };
-        payjoin.contribute_witness_input(txo_to_contribute, outpoint_to_contribute);
-
-        let receiver_substitute_address = bitcoind.get_new_address(None, None).unwrap();
-        payjoin.substitute_output_address(receiver_substitute_address);
-
-        let payjoin_proposal_psbt = payjoin.apply_fee(Some(1)).expect("failed to apply fees");
-
-        log::debug!("Extracted PSBT: {:#?}", payjoin_proposal_psbt);
-        // Sign payjoin psbt
-        let payjoin_base64_string =
-            base64::encode(bitcoin::consensus::serialize(&payjoin_proposal_psbt));
-        // `wallet_process_psbt` adds available utxo data and finalizes
-        let payjoin_proposal_psbt = bitcoind
-            .wallet_process_psbt(&payjoin_base64_string, None, None, Some(false))
-            .unwrap()
-            .psbt;
-        let payjoin_proposal_psbt =
-            load_psbt_from_base64(payjoin_proposal_psbt.as_bytes()).unwrap();
-        let payjoin_proposal_psbt =
-            payjoin.prepare_psbt(payjoin_proposal_psbt).expect("failed to prepare psbt");
-        log::debug!("Receiver's PayJoin proposal PSBT Rsponse: {:#?}", payjoin_proposal_psbt);
-
-        let payload = base64::encode(bitcoin::consensus::serialize(&payjoin_proposal_psbt));
-        log::info!("successful response");
-        Response::text(payload)
-    });
+    let payload = base64::encode(bitcoin::consensus::serialize(&payjoin_proposal_psbt));
+    log::info!("successful response");
+    Response::text(payload)
 }
 
 struct Headers<'a>(rouille::HeadersIter<'a>);

--- a/payjoin/src/input_type.rs
+++ b/payjoin/src/input_type.rs
@@ -1,5 +1,5 @@
 use std::convert::{TryFrom, TryInto};
-use std::fmt;
+use std::fmt::{self, Display};
 
 use bitcoin::blockdata::script::{Instruction, Instructions, Script};
 use bitcoin::blockdata::transaction::TxOut;
@@ -84,6 +84,19 @@ impl InputType {
     }
 }
 
+impl fmt::Display for InputType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InputType::P2Pk => write!(f, "P2PK"),
+            InputType::P2Pkh => write!(f, "P2PKH"),
+            InputType::P2Sh => write!(f, "P2SH"),
+            InputType::SegWitV0 { ty, nested } =>
+                write!(f, "SegWitV0: type={}, nested={}", ty, nested),
+            InputType::Taproot => write!(f, "Taproot"),
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum SegWitV0Type {
     Pubkey,
@@ -107,6 +120,15 @@ impl TryFrom<Instructions<'_>> for SegWitV0Type {
             Instruction::PushBytes(bytes) if bytes.len() == 20 => Ok(SegWitV0Type::Pubkey),
             Instruction::PushBytes(bytes) if bytes.len() == 32 => Ok(SegWitV0Type::Script),
             Instruction::PushBytes(_) | Instruction::Op(_) => Err(InputTypeError::UnknownInputType),
+        }
+    }
+}
+
+impl fmt::Display for SegWitV0Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SegWitV0Type::Pubkey => write!(f, "pubkey"),
+            SegWitV0Type::Script => write!(f, "script"),
         }
     }
 }

--- a/payjoin/src/uri.rs
+++ b/payjoin/src/uri.rs
@@ -172,6 +172,23 @@ impl<'a> bip21::de::DeserializationState<'a> for DeserializationState {
     }
 }
 
+impl std::fmt::Display for PjParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            InternalPjParseError::BadPjOs => write!(f, "Bad pjos parameter"),
+            InternalPjParseError::MultipleParams(param) => {
+                write!(f, "Multiple instances of parameter '{}'", param)
+            }
+            InternalPjParseError::MissingEndpoint => write!(f, "Missing payjoin endpoint"),
+            InternalPjParseError::NotUtf8(_) => write!(f, "Endpoint is not valid UTF-8"),
+            InternalPjParseError::BadEndpoint(_) => write!(f, "Endpoint is not valid"),
+            InternalPjParseError::UnsecureEndpoint => {
+                write!(f, "Endpoint scheme is not secure (https or onion)")
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 enum InternalPjParseError {
     BadPjOs,


### PR DESCRIPTION
Close #47 

- [x] Handle http server errors with http response code 400-500 instead of panic
- [x] return `anyhow::Result`s for send_payjoin and receive_payjoin functions
- [x] impl Display for PjParseError https://github.com/Kixunil/payjoin/issues/37

This leaves a few problems with #50 closures but solves the handles all of the rest of the errors for the cli client